### PR TITLE
Fix an error preventing this lib from working in node.js

### DIFF
--- a/timeshift.js
+++ b/timeshift.js
@@ -220,4 +220,4 @@
 		return "utc=" + this.utc.toUTCString() + "   local=" + utcToLocal(this.utc).toUTCString() + "   offset=" + timezoneOffset;
 	}
 
-}).call(this);
+}).call(typeof global !== 'undefined' ? global : this);


### PR DESCRIPTION
In browsers, it's `window` but in node.js it's `global`. TimeShift-js fails to assign the latter into the `root` variable where it looks for `root.Date`. Thus, if you `require('timeshift-js')` in Node.js, it errors out when it does:

```js
var OriginalDate = root.Date;
var timezoneOffset = new OriginalDate().getTimezoneOffset();
// OriginalDate is undefined
```

This PR fixes that, and meanwhile tests continue to pass in Chrome, Firefox and Safari. I've been playing around with it and once that specific issue is fixed, this lib works great in Node.