### PR TITLE
! Fix Date type should be DateConstructor instead of Date

### DIFF
--- a/timeshift.d.ts
+++ b/timeshift.d.ts
@@ -25,9 +25,9 @@ export function getTimezoneOffset(): number;
 /**
  * Access to the Mocked Date.
  */
-export const Date: Date;
+export const Date: DateConstructor;
 
 /**
  * Access to the original Date constructor.
  */
-export const OriginalDate: Date;
+export const OriginalDate: DateConstructor;


### PR DESCRIPTION
The Javascript "Date" is of Type "DateConstructor".

I did not recognize this issue yesterday for some reason. Sorry