### PR TITLE
adding ability to call setTime with a callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ TimeShift.setTime(1328230923000);           // Set the time to 2012-02-03 01:02:
 new Date().toString();
 "Fri Feb 03 2012 02:02:03 GMT+0100"
 
+TimeShift.setTime(() => {                   // Set the time using a callback that's evaluated each time a new Date is created
+    return 1328230923000;
+});
+new Date().toString();
+"Fri Feb 03 2012 02:02:03 GMT+0100"
+
 TimeShift.setTimezoneOffset(0);             // Set timezone to GMT
 new Date().toString();
 "Fri Feb 03 2012 01:02:03 GMT"
@@ -66,6 +72,22 @@ The default time zone offset is the current local time zone offset.  Note that t
 
 The time zone offset has the same sign as [Date.getTimezoneOffset](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset).  For example, -120 is GMT+0200 and +120 is GMT-0200.
 
+Mocking Passage of Time
+-----------------------
+Once the time is set, the same time will be returned every time you create a new Date object by default. It will not progress with the passage of time. Most of the time this is the desired behavior, but sometimes this can cause issues with things like canvas animations. If you want to maintain the normal passage of time starting with the date you set you can do so as follows:
+
+```javascript
+Date = TimeShift.Date;                                        // Override the Date object as usual
+var originalDate = new TimeShift.OriginalDate().getTime();    // Get the actual date before setting
+var mockTimestamp = 1328230923000;
+
+// Pass a callback to setTime that adds the change in time since the date was mocked to the the mocked time.
+TimeShift.setTime(() => {
+    var dateNow = new TimeShift.OriginalDate().getTime();
+    return mockTimestamp + dateNow - originalDate;
+});
+```
+
 Caveats
 -------
 
@@ -80,7 +102,6 @@ The mock implementation of Date is not perfect.
 * DST changes cannot be emulated.  The time zone offset it always fixed.
 
 * If a library or other code holds an original Date object or a reference to the Date prototype, things may break (e.g. error messages like "this is not a Date object").  In this case you should overwrite the Date object before loading the library.
-
 
 If you'd like to fix some of these issues, please fork the repository, implement the desired functionality, add unit tests to `tests.js` and send a pull request.
 

--- a/README.md
+++ b/README.md
@@ -24,18 +24,22 @@ TimeShift.setTime(1328230923000);           // Set the time to 2012-02-03 01:02:
 new Date().toString();
 "Fri Feb 03 2012 02:02:03 GMT+0100"
 
+var t = 1577836800000;
 TimeShift.setTime(() => {                   // Set the time using a callback that's evaluated each time a new Date is created
-    return 1328230923000;
+    t += 1000;
+    return t;
 });
 new Date().toString();
-"Fri Feb 03 2012 02:02:03 GMT+0100"
+"Wed Jan 01 2020 01:00:01 GMT+0100"
+new Date().toString();
+"Wed Jan 01 2020 01:00:02 GMT+0100"
 
 TimeShift.setTimezoneOffset(0);             // Set timezone to GMT
 new Date().toString();
-"Fri Feb 03 2012 01:02:03 GMT"
+"Wed Jan 01 2020 00:00:03 GMT"
 
-TimeShift.getTime();                        // Get overridden values
-1328230923000
+TimeShift.getTime();                        // Get overridden values (function evaluated)
+1577836804000
 TimeShift.getTimezoneOffset();
 0
 
@@ -79,13 +83,20 @@ Once the time is set, the same time will be returned every time you create a new
 ```javascript
 Date = TimeShift.Date;                                        // Override the Date object as usual
 var originalDate = new TimeShift.OriginalDate().getTime();    // Get the actual date before setting
-var mockTimestamp = 1328230923000;
+var mockTimestamp = 1577836800000;
 
 // Pass a callback to setTime that adds the change in time since the date was mocked to the the mocked time.
 TimeShift.setTime(() => {
     var dateNow = new TimeShift.OriginalDate().getTime();
     return mockTimestamp + dateNow - originalDate;
 });
+
+new Date().toString()
+"Wed Jan 01 2020 00:00:01 GMT"
+new Date().toString()
+"Wed Jan 01 2020 00:00:02 GMT"
+new Date().toString()
+"Wed Jan 01 2020 00:00:03 GMT"
 ```
 
 Caveats

--- a/README.md
+++ b/README.md
@@ -24,24 +24,24 @@ TimeShift.setTime(1328230923000);           // Set the time to 2012-02-03 01:02:
 new Date().toString();
 "Fri Feb 03 2012 02:02:03 GMT+0100"
 
+TimeShift.setTimezoneOffset(0);             // Set timezone to GMT
+new Date().toString();
+"Fri Feb 03 2012 01:02:03 GMT"
+
+TimeShift.getTime();                        // Get overridden values
+1328230923000
+TimeShift.getTimezoneOffset();
+0
+
 var t = 1577836800000;
 TimeShift.setTime(() => {                   // Set the time using a callback that's evaluated each time a new Date is created
     t += 1000;
     return t;
 });
 new Date().toString();
-"Wed Jan 01 2020 01:00:01 GMT+0100"
+"Wed Jan 01 2020 00:00:01 GMT"
 new Date().toString();
-"Wed Jan 01 2020 01:00:02 GMT+0100"
-
-TimeShift.setTimezoneOffset(0);             // Set timezone to GMT
-new Date().toString();
-"Wed Jan 01 2020 00:00:03 GMT"
-
-TimeShift.getTime();                        // Get overridden values (function evaluated)
-1577836804000
-TimeShift.getTimezoneOffset();
-0
+"Wed Jan 01 2020 00:00:02 GMT"
 
 TimeShift.setTime(undefined);               // Reset to current time
 new Date().toString();

--- a/tests.js
+++ b/tests.js
@@ -435,6 +435,17 @@ test("setTime(callback)", function() {
   TimeShift.setTime(undefined);
 });
 
+test("setTime(callback-undefined)", function() {
+  var callback = function() {
+    return undefined;
+  }
+  TimeShift.setTimezoneOffset(-120);
+  TimeShift.setTime(callback);
+  var now = new Date();
+  var d = new TimeShift.Date();
+  ok(now.getTime() - d.getTime() < 500);
+});
+
 ////////////////////  Other functionality  ////////////////////
 
 test("getTime(), valueOf()", function() {

--- a/tests.js
+++ b/tests.js
@@ -423,6 +423,17 @@ test("setTime(time)", function() {
   matchesUTC(d, 2013, AUG, 8, 19, 53, 04, 123, THU);
 });
 
+test("setTime(callback)", function() {
+  var callback = function() {
+    return 1375991584123;  // Thu 2013-08-08 19:53:04.123 UTC
+  }
+  TimeShift.setTimezoneOffset(-120);
+  TimeShift.setTime(callback);
+  var d = new TimeShift.Date();
+  matches(d, 2013, AUG, 8, 21, 53, 4, 123, THU);
+  matchesUTC(d, 2013, AUG, 8, 19, 53, 4, 123, THU);
+  TimeShift.setTime(undefined);
+});
 
 ////////////////////  Other functionality  ////////////////////
 

--- a/timeshift.d.ts
+++ b/timeshift.d.ts
@@ -1,8 +1,8 @@
-export type TimeCallback = () => number;
+export type TimeCallback = () => number | undefined;
 
 /**
  * Set the current time in milliseconds after Jan 1 1970 in UTC time or a callback which
- * returns the time in this format. Setting this to undefined will reset to the real 
+ * returns the time in this format. Setting this to undefined will reset to the real
  * current time.
  */
 export function setTime(millis: number | TimeCallback | undefined): void;

--- a/timeshift.d.ts
+++ b/timeshift.d.ts
@@ -1,8 +1,11 @@
+export type TimeCallback = () => number;
+
 /**
- * Set the current time in milliseconds after Jan 1 1970 in UTC time.  Setting this
- * to undefined will reset to the real current time.
+ * Set the current time in milliseconds after Jan 1 1970 in UTC time or a callback which
+ * returns the time in this format. Setting this to undefined will reset to the real 
+ * current time.
  */
-export function setTime(millis: number | undefined): void;
+export function setTime(millis: number | TimeCallback | undefined): void;
 
 /**
  * @return the currently overridden time value as milliseconds after Jan 1 1970 in UTC time.

--- a/timeshift.js
+++ b/timeshift.js
@@ -22,8 +22,9 @@
 	var timezoneOffset = new OriginalDate().getTimezoneOffset();
 	
 	function currentDate() {
-		if (currentTime) {
-			return new OriginalDate(currentTime);
+		var time = TimeShift.getTime();
+		if (time) {
+			return new OriginalDate(time);
 		} else {
 			return new OriginalDate();
 		}
@@ -77,10 +78,14 @@
 	}
 	
 	/**
-	 * Return the currently overridden time value as milliseconds after Jan 1 1970 in UTC time.
-	 * The default value is undefined, which indicates using the real current time.
+	 * Return the currently overridden time value as milliseconds after Jan 1 1970 in UTC time
+	 * or a callback which returns the time in this format. The default value is undefined, which
+	 * indicates using the real current time.
 	 */
 	TimeShift.getTime = function() {
+		if (typeof currentTime === 'function') {
+			return currentTime();
+		}
 		return currentTime;
 	}
 

--- a/timeshift.js
+++ b/timeshift.js
@@ -23,7 +23,10 @@
 	
 	function currentDate() {
 		var time = TimeShift.getTime();
-		if (time) {
+		if (typeof time === 'function') {
+			time = time();
+		}
+		if (time !== undefined) {
 			return new OriginalDate(time);
 		} else {
 			return new OriginalDate();
@@ -78,20 +81,16 @@
 	}
 	
 	/**
-	 * Return the currently overridden time value as milliseconds after Jan 1 1970 in UTC time
-	 * or a callback which returns the time in this format. The default value is undefined, which
-	 * indicates using the real current time.
+	 * Return the currently overridden time value set by `TimeShift.setTime`, or undefined if
+	 * not overridden.
 	 */
 	TimeShift.getTime = function() {
-		if (typeof currentTime === 'function') {
-			return currentTime();
-		}
 		return currentTime;
 	}
 
 	/**
-	 * Set the current time in milliseconds after Jan 1 1970 in UTC time.  Setting this
-	 * to undefined will reset to the real current time.
+	 * Set the current time in milliseconds after Jan 1 1970 in UTC time, or a callback
+	 * which returns the same.  Setting this to undefined will reset to the real current time.
 	 */
 	TimeShift.setTime = function(time) {
 		currentTime = time;


### PR DESCRIPTION
Have added the ability to pass a callback to setTime. If a callback is passed, it will be called each time the date is evaluated. Also added docs of this feature and how to use it to maintain the normal flow of time.

Shout if there's anything you'd like me to change about it.