### PR TITLE
Return the correct toString() text for invalid dates

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -503,6 +503,8 @@ test("toString(); invalid date", function() {
   TimeShift.setTimezoneOffset(0);
   var d = new TimeShift.Date("");
   equal(d.toString(), "Invalid Date");
+  d = new TimeShift.Date(NaN);
+  equal(d.toString(), 'Invalid Date');
 });
 
 test("toUTCString()", function() {

--- a/tests.js
+++ b/tests.js
@@ -499,6 +499,12 @@ test("toString() 3", function() {
   equal(d.toString(), "Sun Jan 01 2012 06:07:08 GMT");
 });
 
+test("toString(); invalid date", function() {
+  TimeShift.setTimezoneOffset(0);
+  var d = new TimeShift.Date("");
+  equal(d.toString(), "Invalid Date");
+});
+
 test("toUTCString()", function() {
   TimeShift.setTimezoneOffset(-300);
   var d = new TimeShift.Date(2012, MAR, 5, 23, 45, 12, 123);  // Mon 2012-03-05 23:45:12.123 +0500

--- a/timeshift.js
+++ b/timeshift.js
@@ -196,6 +196,12 @@
 		var wkdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 		var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 		var d = utcToLocal(this.utc);
+
+		// Match browser behavior for invalid dates
+		if (d.toString() === "Invalid Date") {
+			return d.toString();
+		}
+
 		// Mon Mar 05 2012 06:07:08 GMT+0500
 		return wkdays[d.getUTCDay()] + " " + months[d.getUTCMonth()] + " " + twoDigit(d.getUTCDate()) + " " + d.getUTCFullYear() +
 			" " + twoDigit(d.getUTCHours()) + ":" + twoDigit(d.getUTCMinutes()) + ":" + twoDigit(d.getUTCSeconds()) + " " + timezoneName();


### PR DESCRIPTION
According to the [ECMAScript spec for the date](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tostring) we have to return `Invalid Date` if a user constructs an invalid date. Failure to do so means that some libraries (e.g. dayjs) can't recognize that a date is invalid and therefore don't work correctly.